### PR TITLE
Use latest playbooks (196bc9c)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([fullversion], [base_version-git_commit_count-date[git]git_revision])
 
 AC_INIT([eucalyptus-ansible], [fullversion])
 
-PLAYBOOK_COMMIT=0038819c59d84f64912058a88dd0fa2e9c8a85d6
+PLAYBOOK_COMMIT=196bc9c87f22d7245a7d591786f552f2ba996819
 PLAYBOOK_ORG=appscale
 
 AC_ARG_WITH(playbook-commit,


### PR DESCRIPTION
Update for AppScale/ats-deploy#11 (yum repository configuration options)

Build: /job/eucalyptus-internal-5-build-random-rpms/219/
Stage: /job/eucalyptus-internal-5-stage-random/181/
Deploy: /job/eucalyptus-5-ansible-deploy/143/

Demo is that the ansible deploy is successful and that the update is present in the rpm:

```
# 
# grep -r 'eucalyptus-base' /usr/share/eucalyptus-ansible/
/usr/share/eucalyptus-ansible/roles/common/tasks/yum_repos.yml:    src: eucalyptus-base.repo.j2
/usr/share/eucalyptus-ansible/roles/common/tasks/yum_repos.yml:    dest: /etc/yum.repos.d/eucalyptus-base.repo
/usr/share/eucalyptus-ansible/roles/common/templates/eucalyptus-base.repo.j2:[eucalyptus-base]
# 
# 
# ls -1 /etc/yum.repos.d/euca*
/etc/yum.repos.d/euca2ools.repo
/etc/yum.repos.d/eucalyptus.repo
# 
```

But the base repository is not enabled by default.