### PR TITLE
Use latest playbooks (e1a10c3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([fullversion], [base_version-git_commit_count-date[git]git_revision])
 
 AC_INIT([eucalyptus-ansible], [fullversion])
 
-PLAYBOOK_COMMIT=196bc9c87f22d7245a7d591786f552f2ba996819
+PLAYBOOK_COMMIT=e1a10c3a597a185eee9e7b9d11e17fb88cf5925b
 PLAYBOOK_ORG=appscale
 
 AC_ARG_WITH(playbook-commit,


### PR DESCRIPTION
Update for AppScale/ats-deploy#12 (EDGE mode for simple deployments) and AppScale/ats-deploy#13 (dnsdist public dns)

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=425
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/17/ (vpc dnsdist) /job/eucalyptus-internal-5-ado-ansible-deploy/18/ (edge)
Test: /job/eucalyptus-5-qa-fast/54/ /job/eucalyptus-5-qa-fast/55/

Demo is that vpc deployment is using dnsdist:

```
# 
# rpm -qa eucalyptus
eucalyptus-5.0.0-0.86.ansdnsedge.el7.x86_64
# 
# 
# euca-describe-account-attributes 
ACCOUNTATTRIBUTE	supported-platforms
VALUE	VPC
ACCOUNTATTRIBUTE	default-vpc
VALUE	vpc-4b87aafc9b12e0288
# 
#
# netstat -nulp | grep 53
udp        0      0 10.117.111.14:53        0.0.0.0:*                           1324/java           
udp        0      0 192.168.111.14:53       0.0.0.0:*                           1805/dnsdist        
udp        0      0 192.168.111.14:8753     0.0.0.0:*                           1324/java           
udp        0      0 10.116.111.14:8753      0.0.0.0:*                           1324/java           
udp        0      0 10.117.111.14:8753      0.0.0.0:*                           1324/java           
udp        0      0 10.234.234.234:8753     0.0.0.0:*                           1324/java           
# 
```

and the edge deployment does not (as per deployment options):

```
# 
# rpm -qa eucalyptus
eucalyptus-5.0.0-0.86.ansdnsedge.el7.x86_64
# 
# 
# euca-describe-account-attributes 
ACCOUNTATTRIBUTE	supported-platforms
VALUE	EC2
ACCOUNTATTRIBUTE	default-vpc
VALUE	none
# 
# 
# netstat -nulp | grep 53
udp        0      0 192.168.111.14:53       0.0.0.0:*                           1309/java           
udp        0      0 10.116.111.14:53        0.0.0.0:*                           1309/java           
udp        0      0 10.117.111.14:53        0.0.0.0:*                           1309/java           
# 
```
