### PR TITLE
Use latest playbooks (d90c492)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([fullversion], [base_version-git_commit_count-date[git]git_revision])
 
 AC_INIT([eucalyptus-ansible], [fullversion])
 
-PLAYBOOK_COMMIT=e1a10c3a597a185eee9e7b9d11e17fb88cf5925b
+PLAYBOOK_COMMIT=d90c492a391da10e68d19fba6445ac15e0803cd8
 PLAYBOOK_ORG=appscale
 
 AC_ARG_WITH(playbook-commit,


### PR DESCRIPTION
Update to the latest playbooks for:

* AppScale/ats-deploy#14  console deployment as stack
* AppScale/ats-deploy#15 systemd units remove on clean
* AppScale/ats-deploy#16 firewalld cluster zone should allow gre traffic
* AppScale/ats-deploy#17 service image install latest from downloads

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=504
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/46/
Test: /job/eucalyptus-5-qa-fast/77/

Demo is that the service image utility script is available:

```
# eucalyptus-system-images --report
TYPE	eucalyptus-console-image	VERSION	5.0.484
TYPE	eucalyptus-service-image	VERSION	5.0.100.483
```

and that the console cloudformation templates are installed:

```
# ls -1 /var/lib/eucalyptus/templates/console*.yaml
/var/lib/eucalyptus/templates/console-eip-template.yaml
/var/lib/eucalyptus/templates/console-template.yaml
```

see also demos on ats-deploy pull requests.