### PR TITLE
Use latest playbooks (d4de3dd)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([fullversion], [base_version-git_commit_count-date[git]git_revision])
 
 AC_INIT([eucalyptus-ansible], [fullversion])
 
-PLAYBOOK_COMMIT=d90c492a391da10e68d19fba6445ac15e0803cd8
+PLAYBOOK_COMMIT=d4de3ddb59692ea5b53a0f7175bc9a672b1e8294
 PLAYBOOK_ORG=appscale
 
 AC_ARG_WITH(playbook-commit,


### PR DESCRIPTION
Update to the latest playbooks for:

* AppScale/ats-deploy#19 das manager support
* AppScale/ats-deploy#20 tgtd listen interface
* AppScale/ats-deploy#21 playbook systemd image tag fix
* AppScale/ats-deploy#22 midonet naming
* AppScale/ats-deploy#23 minio objectstorage support
* AppScale/ats-deploy#24 ceph osd pool pg_num
* AppScale/ats-deploy#25 eucanetd netns fix
* AppScale/ats-deploy#26 eucalyptus-account utility

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=593
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/82/ 
Test: /job/eucalyptus-5-qa-fast/97/

Demo is that the `eucalyptus-account` utility is present:

```
# eucalyptus-account list --account eucalyptus
BUCKET centos-7-x86-64-genericcloud
BUCKET eucalyptus-service-image-v5.0.100
...
```

network namespaces can be listed:

```
# ip netns list
vpc-e35684445eec25f61 (id: 1)
vpc-a36544785ec9cfb44 (id: 0)
```

midonet repositories are present:

```
# ls -1 /etc/yum.repos.d/midonet*
/etc/yum.repos.d/midonet-misc.repo
/etc/yum.repos.d/midonet.repo
```

tgtd is listening on a configured interface:

```
# ss -nltp | grep tgtd
LISTEN     0      128    10.117.111.43:3260                     *:*                   users:(("tgtd",pid=1496,fd=6))
```

see also demos on ats-deploy pull requests.