### PR TITLE
Use latest playbooks (187d7ba)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([fullversion], [base_version-git_commit_count-date[git]git_revision])
 
 AC_INIT([eucalyptus-ansible], [fullversion])
 
-PLAYBOOK_COMMIT=d4de3ddb59692ea5b53a0f7175bc9a672b1e8294
+PLAYBOOK_COMMIT=187d7ba1a909c3fbe967ecbcc615a0bf7f4a72c5
 PLAYBOOK_ORG=appscale
 
 AC_ARG_WITH(playbook-commit,


### PR DESCRIPTION
Update to the latest playbooks for:

*  AppScale/ats-deploy#27 web services listener default cidr
*  AppScale/ats-deploy#28 eucalyptus-images identifier prefix
*  AppScale/ats-deploy#29 libvirtd cluster listener address
*  AppScale/ats-deploy#30 host network interfaces
*  AppScale/ats-deploy#31 create accounts

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=657
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/112/
Test: /job/eucalyptus-5-qa-fast/119/

Demos as per ats-deploy pull requests.