### PR TITLE
Use latest playbooks (9920499)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([fullversion], [base_version-git_commit_count-date[git]git_revision])
 
 AC_INIT([eucalyptus-ansible], [fullversion])
 
-PLAYBOOK_COMMIT=a91a975fbd33fd94cb091791b203f342fe1f82f9
+PLAYBOOK_COMMIT=9920499deab0388ea05b67dafcf50b3429ff2b89
 PLAYBOOK_ORG=appscale
 
 AC_ARG_WITH(playbook-commit,


### PR DESCRIPTION
Update to the latest playbooks for:

* AppScale/ats-deploy#34 Default ceph facts delegate to empty string

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=738
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/143/
Test: /job/eucalyptus-5-qa-fast/128/

Demo is that vpc/ceph qa deployments are now successful