### PR TITLE
Use latest playbooks (99506b8) update rpm version (5.0.101)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-m4_define([base_version], [5.0.100])
+m4_define([base_version], [5.0.101])
 m4_define([git_revision],
           m4_esyscmd([git rev-parse HEAD | cut -c-7 | tr -d '\n']))
 m4_define([git_commit_count],
@@ -8,7 +8,7 @@ m4_define([fullversion], [base_version-git_commit_count-date[git]git_revision])
 
 AC_INIT([eucalyptus-ansible], [fullversion])
 
-PLAYBOOK_COMMIT=9920499deab0388ea05b67dafcf50b3429ff2b89
+PLAYBOOK_COMMIT=99506b823e8c9096de3e628d75d9e585ce7200aa
 PLAYBOOK_ORG=appscale
 
 AC_ARG_WITH(playbook-commit,

--- a/eucalyptus-ansible.spec
+++ b/eucalyptus-ansible.spec
@@ -1,5 +1,5 @@
 Name:           eucalyptus-ansible
-Version:        5.0.100
+Version:        5.0.101
 Release:        0%{?build_id:.%build_id}%{?dist}
 Summary:        Ansible playbooks for Eucalyptus
 


### PR DESCRIPTION
Update to the latest playbooks for:

* AppScale/ats-deploy#35 Eucalyptus configuration for external database
* AppScale/ats-deploy#36 Console stack update change/failure detection
* AppScale/ats-deploy#37 CentOS virtualization distribution check
* AppScale/ats-deploy#38 Use release yum repository by default
* AppScale/ats-deploy#39 Ceph hosts epel yum repository and ssh option
* AppScale/ats-deploy#40 Firewalld reload option
* AppScale/ats-deploy#41 Cloud post services certbot script for multiple hosts
* AppScale/ats-deploy#42 Cloud console deployment ssh key configuration
* AppScale/ats-deploy#43 Eucalyptus package version configuration
* AppScale/ats-deploy#44 eucalyptus-certbot-hook lookup service port
* AppScale/ats-deploy#45 Console cloud deployment certbot initialization

The version is incremented and this should be used for all 5.x deployments.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=866
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/208/
Test: /job/eucalyptus-5-qa-fast/158/