### PR TITLE
Use latest playbooks (a1fee9a) update rpm version (5.0.102)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-m4_define([base_version], [5.0.101])
+m4_define([base_version], [5.0.102])
 m4_define([git_revision],
           m4_esyscmd([git rev-parse HEAD | cut -c-7 | tr -d '\n']))
 m4_define([git_commit_count],
@@ -8,7 +8,7 @@ m4_define([fullversion], [base_version-git_commit_count-date[git]git_revision])
 
 AC_INIT([eucalyptus-ansible], [fullversion])
 
-PLAYBOOK_COMMIT=99506b823e8c9096de3e628d75d9e585ce7200aa
+PLAYBOOK_COMMIT=a1fee9a63f4e561492a1b6cd5af83c33c2791dce
 PLAYBOOK_ORG=appscale
 
 AC_ARG_WITH(playbook-commit,

--- a/eucalyptus-ansible.spec
+++ b/eucalyptus-ansible.spec
@@ -1,5 +1,5 @@
 Name:           eucalyptus-ansible
-Version:        5.0.101
+Version:        5.0.102
 Release:        0%{?build_id:.%build_id}%{?dist}
 Summary:        Ansible playbooks for Eucalyptus
 


### PR DESCRIPTION
Update to the latest playbooks for:

* AppScale/ats-deploy#46 Cloud services certificate service regions
* AppScale/ats-deploy#47 Ceph disable snapshot s3 transfer
* AppScale/ats-deploy#48 eucalyptus-certbot-hook target protocol
* AppScale/ats-deploy#49 Ceph deployment allow multiple osds per host
* AppScale/ats-deploy#50 Network allow multiple ip ranges
* AppScale/ats-deploy#51 Ceph role set minimum client version
* AppScale/ats-deploy#52 System images script artifact versions
* AppScale/ats-deploy#53 Cloud console template for custom https
* AppScale/ats-deploy#54 CloudFormation dns template ttl settings
* AppScale/ats-deploy#55 Fix use of shell quote filter
* AppScale/ats-deploy#56 Console role support for route53 dns record
* AppScale/ats-deploy#57 Network allow multiple ip ranges, firewall

The version is incremented and this should be used for all 5.x deployments.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1132
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1133