### PR TITLE
Use latest playbooks (ca53485)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ m4_define([fullversion], [base_version-git_commit_count-date[git]git_revision])
 
 AC_INIT([eucalyptus-ansible], [fullversion])
 
-PLAYBOOK_COMMIT=a1fee9a63f4e561492a1b6cd5af83c33c2791dce
+PLAYBOOK_COMMIT=ca534852de294fdf341feb971fb2cd849c302802
 PLAYBOOK_ORG=appscale
 
 AC_ARG_WITH(playbook-commit,


### PR DESCRIPTION
Update to the latest playbooks for:

* AppScale/ats-deploy#58 Console role retry https certificate provisioning

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1186
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1187